### PR TITLE
Allow reward range 24

### DIFF
--- a/Assets/Script/Loja.cs
+++ b/Assets/Script/Loja.cs
@@ -347,7 +347,7 @@ public class Loja : MonoBehaviour
          * 24 Poder Vida
         */
 
-        int randomIndex = Random.Range(0, 24);
+        int randomIndex = Random.Range(0, 25);
         print(randomIndex);
 
         if (randomIndex >= 0 && randomIndex <= 10)


### PR DESCRIPTION
## Summary
- allow random rewards to select the value 24

## Testing
- `mcs -recurse:Assets/Script/*.cs -r:Library/PlayerDataCache/Data/Managed/UnityEngine.dll -r:Library/PlayerDataCache/Data/Managed/UnityEngine.UI.dll -r:Library/PlayerDataCache/Data/Managed/UnityEngine.Advertisements.dll -r:Library/PlayerDataCache/Data/Managed/UnityEngine.Networking.dll -r:Library/PlayerDataCache/Data/Managed/UnityEngine.Timeline.dll -define:UNITY_ANDROID -target:library -out:/tmp/game.dll`


------
https://chatgpt.com/codex/tasks/task_e_684899afedc083329987674b488ce5b1